### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/tests/test-helper.el
+++ b/tests/test-helper.el
@@ -8,6 +8,5 @@
 (require 'undercover nil t)
 (undercover "*.el" (:report-format 'simplecov) (:send-report nil))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here
 


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`. Instead `ert-runner` loads it using `load`.  Other packages that use `ert-runner` also come with a file named test-helper.el and unfortunately many of those also provide `test-helper`, which leads to conflicts.

Also see rejeep/ert-runner.el#38.
Closes #15.